### PR TITLE
Multiple improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 jekyll-toc-generator
 ====================
 
-Liquid filter to generate Table of Content into Jeklyll pages 
+Liquid filter to generate Table of Content into Jeklyll pages
 
 This filter adds to jekyll pages a Table of Content (TOC), it generates the necessary HTML code.
 
@@ -55,7 +55,7 @@ It is possible to suppress the TOC generation in specific pages, for example the
 This can be done into the [Front Matter](http://jekyllrb.com/docs/frontmatter/) section used by jekyll
 
 
-You must add the `noToc: true` directive
+You must add the `noToc: true` directive:
 
     ---
     permalink: index.html
@@ -64,6 +64,19 @@ You must add the `noToc: true` directive
     noToc: true
     ---
 
+# Limit the TOC to a single level
+
+It is possible to limit the TOC generation in specific pages to a single level.  
+This can be done into the [Front Matter](http://jekyllrb.com/docs/frontmatter/) section used by jekyll.
+
+You must add the `tocLevels: 1` directive:
+
+    ---
+    permalink: /reference/
+    layout: page
+    title: Reference
+    tocLevels: 1
+    ---
 
 # Advanced configuration
 
@@ -140,7 +153,7 @@ For example the markdown code shown below
     heading 1
     =========
 
-    blah blah 
+    blah blah
 
     heading 1.1
     -----------

--- a/README.md
+++ b/README.md
@@ -78,6 +78,20 @@ You must add the `tocLevels: 1` directive:
     tocLevels: 1
     ---
 
+# Preserve existing anchor names
+
+If the markdown was processed with `with_toc_data`, the header definitions already include proper anchors, and the TOC can directly use them.
+
+This can be enabled in the [Front Matter](http://jekyllrb.com/docs/frontmatter/) section used by jekyll.
+
+    ---
+    permalink: /reference/
+    layout: page
+    title: Reference
+    useExistingAnchors: true
+    ---
+
+
 # Advanced configuration
 
 Normally no configuration is necessary but you can set some parameter into you `_config.yml` file

--- a/_plugins/tocGenerator.rb
+++ b/_plugins/tocGenerator.rb
@@ -110,7 +110,8 @@ module Jekyll
         doc.css('body').children.before(toc_table)
       end
 
-      doc.css('body').children.to_xhtml(indent:3, indent_text:" ")
+      # doc.css('body').children.to_xhtml(indent:3, indent_text:" ")
+      doc.css('body').children.to_xhtml(indent:0)
     end
 
     private

--- a/_plugins/tocGenerator.rb
+++ b/_plugins/tocGenerator.rb
@@ -23,6 +23,7 @@ module Jekyll
       min_items_to_show_toc = config["minItemsToShowToc"] || 0
 
       anchor_prefix = config["anchorPrefix"] || 'tocAnchor-'
+      use_existing_anchors = config["useExistingAnchors"] || false
 
       # better for traditional page seo, commonlly use h1 as title
       toc_top_tag = config["tocTopTag"] || 'h1'
@@ -61,12 +62,16 @@ module Jekyll
         if toc_levels > 1
           sects.map.each do |sect|
             inner_section += 1;
-            anchor_id = [
+            if use_existing_anchors && sect['id']
+              anchor_id = sect['id'];
+            else
+              anchor_id = [
                           anchor_prefix, toc_level, '-', toc_section, '-',
                           inner_section
                         ].map(&:to_s).join ''
+              sect['id'] = "#{anchor_id}"
+            end
 
-            sect['id'] = "#{anchor_id}"
 
             level_html += create_level_html(anchor_id,
                                             toc_level + 1,
@@ -79,8 +84,12 @@ module Jekyll
 
         level_html = '<ul>' + level_html + '</ul>' if level_html.length > 0
 
-        anchor_id = anchor_prefix + toc_level.to_s + '-' + toc_section.to_s;
-        tag['id'] = "#{anchor_id}"
+        if use_existing_anchors && tag['id']
+          anchor_id = tag['id'];
+        else
+          anchor_id = anchor_prefix + toc_level.to_s + '-' + toc_section.to_s;
+          tag['id'] = "#{anchor_id}"
+        end
 
         toc_html += create_level_html(anchor_id,
                                       toc_level,

--- a/_plugins/tocGenerator.rb
+++ b/_plugins/tocGenerator.rb
@@ -15,6 +15,8 @@ module Jekyll
 
       return html if no_toc
 
+      toc_levels = @context.environments.first["page"]["tocLevels"] || 2;
+
       config = @context.registers[:site].config
 
       # Minimum number of items needed to show TOC, default 0 (0 means no minimum)
@@ -56,21 +58,23 @@ module Jekyll
         level_html    = '';
         inner_section = 0;
 
-        sects.map.each do |sect|
-          inner_section += 1;
-          anchor_id = [
-                        anchor_prefix, toc_level, '-', toc_section, '-',
-                        inner_section
-                      ].map(&:to_s).join ''
+        if toc_levels > 1
+          sects.map.each do |sect|
+            inner_section += 1;
+            anchor_id = [
+                          anchor_prefix, toc_level, '-', toc_section, '-',
+                          inner_section
+                        ].map(&:to_s).join ''
 
-          sect['id'] = "#{anchor_id}"
+            sect['id'] = "#{anchor_id}"
 
-          level_html += create_level_html(anchor_id,
-                                          toc_level + 1,
-                                          toc_section + inner_section,
-                                          item_number.to_s + '.' + inner_section.to_s,
-                                          sect.text,
-                                          '')
+            level_html += create_level_html(anchor_id,
+                                            toc_level + 1,
+                                            toc_section + inner_section,
+                                            item_number.to_s + '.' + inner_section.to_s,
+                                            sect.text,
+                                            '')
+          end
         end
 
         level_html = '<ul>' + level_html + '</ul>' if level_html.length > 0
@@ -120,7 +124,7 @@ module Jekyll
       link = '<a href="#%1"><span class="tocnumber">%2</span> <span class="toctext">%3</span></a>%4'
       .gsub('%1', anchor_id.to_s)
       .gsub('%2', tocNumber.to_s)
-      .gsub('%3', tocText)
+      .gsub('%3', tocText.encode(:xml => :text))
       .gsub('%4', tocInner ? tocInner : '');
       '<li class="toc_level-%1 toc_section-%2">%3</li>'
       .gsub('%1', toc_level.to_s)


### PR DESCRIPTION
## Remove indentation spaces, since they are harmful to `<pre><code>`

When displaying code, the correct html generated from markdown looks like:

```
<div class="highlight"><pre><code class="language-text" data-lang="text">Code line 1
Code line 2
</code></pre></div>
```

After running the html via the `toc_generate` filter, the html is damaged, it looks like:

```
<div class="highlight">
   <pre>
      <code class="language-text" data-lang="text">Code line 1
Code line 2
</code>
   </pre>
```

The extra spaces added by the indentation between `<pre>` and `<code>` are preserved in the output, and the first code line is displayed unaligned.

This patch removes the indentation and so fixes the first line display.

Unfortunately there is a second problem with the modified html, there is an extra line displayed at the end of the code, caused by having `</code>` and `</pre>` on separate lines.

Currently I do not know how to fix this, it seems to be a problem inside the html parser or the serialiser.
