### PR TITLE
Don't use global indent because of <code> tags

### DIFF
--- a/_plugins/tocGenerator.rb
+++ b/_plugins/tocGenerator.rb
@@ -110,7 +110,8 @@ module Jekyll
         doc.css('body').children.before(toc_table)
       end
 
-      doc.css('body').children.to_xhtml(indent:3, indent_text:" ")
+      #doc.css('body').children.to_xhtml(indent:3, indent_text:" ")
+      doc.to_xhtml
     end
 
     private


### PR DESCRIPTION
When <code> tags (~~~ in md) are used some programming languages (like python) are very sensitive for indent