### PR TITLE
docs(readme): fix typo: jeklyll -> jekyll

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 jekyll-toc-generator
 ====================
 
-Liquid filter to generate Table of Content into Jeklyll pages 
+Liquid filter to generate Table of Content into Jekyll pages 
 
 This filter adds to jekyll pages a Table of Content (TOC), it generates the necessary HTML code.
 


### PR DESCRIPTION
this typo is also present in the github description